### PR TITLE
Correct LSIIC Dependencies

### DIFF
--- a/Database/dependencies.json
+++ b/Database/dependencies.json
@@ -140,7 +140,7 @@
 			"Website": "https://github.com/BlockBuilder57/LSIIC/",
 			"Arguments": "addFolder?VirtualObjects/?unzipToDir?",
 			"DelInfo": "BepInEx/monomod/LSIIC/?Mods/LSIIC.h3mod",
-			"Dependencies": [ "bepinex", "deli" ]
+			"Dependencies": [ "bepinex" ]
 		},
 		{
 			"modID": "h3vrutils",

--- a/Database/dependencies.json
+++ b/Database/dependencies.json
@@ -140,7 +140,7 @@
 			"Website": "https://github.com/BlockBuilder57/LSIIC/",
 			"Arguments": "addFolder?VirtualObjects/?unzipToDir?",
 			"DelInfo": "BepInEx/monomod/LSIIC/?Mods/LSIIC.h3mod",
-			"Dependencies": [ "bepinex" ]
+			"Dependencies": [ "bepinex", "sideloader" ]
 		},
 		{
 			"modID": "h3vrutils",


### PR DESCRIPTION
- Remove Deli from dependencies. LSIIC does not use Deli
- Add Sideloader to dependencies. LSIIC uses Sideloader to load items such as mod panel