### PR TITLE
wurstmod_deli30 required deli legacy

### DIFF
--- a/Database/dependencies.json
+++ b/Database/dependencies.json
@@ -98,7 +98,7 @@
 			"Website": "https://github.com/Nolenz/WurstMod/",
 			"Arguments": "moveToFolder?WurstMod.deli?Deli/Mods/?WurstMod.deli",
 			"DelInfo": "Deli/Mods/WurstMod.deli",
-			"Dependencies": [ "bepinex", "deli" ],
+			"Dependencies": [ "bepinex", "deli_experimental" ],
 			"IncompatableMods": [ "wurstmod" ]
 		},
 		{


### PR DESCRIPTION
wurstmod_deli30 required deli legacy, replaced with requiring deli_experimental since the automatic dep downloader downloads legacy deli.  Doesn't actually seem to break anything, but it seems not intended.  Let me know if this is, in fact, intended.